### PR TITLE
Stop shiny-server starting when the container runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN Rscript -e 'BiocManager::install(pkgs=c("DEP", "SummarizedExperiment", "limm
 COPY ./ /srv/shiny-server/lfq-analyst
 COPY shiny-server.conf /etc/shiny-server/shiny-server.conf
 
-EXPOSE 8888
+# disable shiny-server
+RUN touch /etc/services.d/shiny-server/down
+
 #RUN rm -f /srv/shiny-server/lfq-analyst/.Rprofile
 RUN chmod -R +r /srv/shiny-server/lfq-analyst


### PR DESCRIPTION
Hi,

Running this container on Galaxy seems to launch two shiny servers, one from the [call to `LFQAnalyst()`](https://github.com/usegalaxy-au/tools-au/blob/26efa3be7bf71f7785ebbedbbda73c8d82ad593a/tools/interactivetool_lfqanalyst/interactivetool_lfqanalyst.xml#L48), and one from the [base image](https://github.com/rocker-org/rocker-versioned2/blob/ef593dcd7b334e02e79188a9e17dcf6149c178b9/dockerfiles/shiny_4.2.3.Dockerfile#L16).

Touching `/etc/services.d/shiny-server/down` disables the server in the base image (documented [here](http://skarnet.org/software/s6/servicedir.html))

It also means we can use port 3838 as [specified in the shiny base image](https://github.com/rocker-org/rocker-versioned2/blob/ef593dcd7b334e02e79188a9e17dcf6149c178b9/dockerfiles/shiny_4.2.3.Dockerfile#L14) so we no longer need `EXPOSE 8888` .

This is not urgent but if you could change it next time you update lfq-analyst, we will switch back to the default port.

Thanks!